### PR TITLE
Fix missing showStatus implementation

### DIFF
--- a/simple_pdf_generator.html
+++ b/simple_pdf_generator.html
@@ -653,10 +653,16 @@
         }
         
         function showSaveStatus() {
+            showStatus('Saved!');
+        }
+
+        function showStatus(message) {
             const status = document.getElementById('saveStatus');
+            status.textContent = message;
             status.classList.add('show');
             setTimeout(() => {
                 status.classList.remove('show');
+                status.textContent = 'Saved!';
             }, 2000);
         }
         


### PR DESCRIPTION
## Summary
- fix bug when saving or clearing responses
- add a helper to show custom status messages

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684868eba0588323aaaba07d5982bab6